### PR TITLE
fix for crash where NSData constructor not expecting nil

### DIFF
--- a/Pod/Classes/Api/SLApiBase.m
+++ b/Pod/Classes/Api/SLApiBase.m
@@ -151,6 +151,9 @@ static NSString *const kVersion = @"v";
 
         NSDictionary *userInfo = nsError.userInfo;
         NSString *errorString = userInfo[SLErrorKey];
+        if (errorString == nil) {
+            errorString = userInfo[NSLocalizedDescriptionKey];
+        }
 
         NSData *errorData = [errorString dataUsingEncoding:NSUTF8StringEncoding];
         NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:errorData


### PR DESCRIPTION
`NSString *errorString = userInfo[SLErrorKey];` returns `nil`, so the following `NSData` constructor will crash the app. This pull request will replace `nil`-value for at least NSLocalizedDesc. And finally we would be able to see the next in the log:
<img width="589" alt="screen shot 2016-04-23 at 5 00 35" src="https://cloud.githubusercontent.com/assets/868077/14758686/ac59f446-0919-11e6-9115-c0cc29a6df09.png">
:)
